### PR TITLE
fix: resolveWith now invalidates the cache

### DIFF
--- a/src/resolver/__tests__/resolveWith.test.ts
+++ b/src/resolver/__tests__/resolveWith.test.ts
@@ -60,3 +60,22 @@ test('it resolves with type inference (6)', t => {
 
   t.is(result, 'abcdefg');
 });
+
+test('it resolves different values for different arguments', t => {
+  const { jpex } = t.context;
+  type A = string;
+  type B = string;
+
+  jpex.factory<A>((b: B) => `a${b}`);
+  jpex.factory<B>(() => 'z');
+
+  const result1 = jpex.resolveWith<A, B>([ 'b' ]);
+  const result2 = jpex.resolveWith<A, B>([ 'c' ]);
+  const result3 = jpex.resolveWith<A, B>([ 'd' ]);
+  const result4 = jpex.resolve<A>();
+
+  t.is(result1, 'ab');
+  t.is(result2, 'ac');
+  t.is(result3, 'ad');
+  t.is(result4, 'az');
+});

--- a/src/resolver/resolve.ts
+++ b/src/resolver/resolve.ts
@@ -27,6 +27,19 @@ const getNamedParameters = (namedParameters: NamedParameters, opts: ResolveOpts 
   return {};
 };
 
+const isResolvedWithParams = (factory: Factory, opts: ResolveOpts = {}) => {
+  if (!factory.with && !opts.with) {
+    return true;
+  }
+  const keys = [
+    ...new Set([
+      ...Object.keys(opts?.with || {}),
+      ...Object.keys(factory.with || {}),
+    ]),
+  ];
+  return keys.every(key => opts?.with?.[key] === factory.with[key]);
+};
+
 const resolveFactory = <R>(
   jpex: JpexInstance,
   name: string,
@@ -39,8 +52,9 @@ const resolveFactory = <R>(
     return;
   }
 
+  
   // Check if it's already been resolved
-  if (factory.resolved) {
+  if (factory.resolved && isResolvedWithParams(factory, opts)) {
     return factory.value;
   }
 
@@ -55,7 +69,7 @@ const resolveFactory = <R>(
   // Invoke the factory
   const value = factory.fn.apply(jpex, args);
   // Cache the result
-  cacheResult(jpex, name, factory, value, namedParameters);
+  cacheResult(jpex, name, factory, value, namedParameters, opts?.with);
 
   return value;
 };

--- a/src/resolver/utils.ts
+++ b/src/resolver/utils.ts
@@ -125,16 +125,20 @@ export const cacheResult = (
   factory: Factory,
   value: any,
   namedParameters: NamedParameters,
+  withArg: Record<string, any>,
 ) => {
   switch (factory.lifecycle) {
   case 'application':
     factory.resolved = true;
     factory.value = value;
+    factory.with = withArg;
     break;
   case 'class':
     jpex.$$resolved[name] = {
+      ...factory,
       resolved: true,
       value,
+      with: withArg,
     } as Factory;
     break;
   case 'none':

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,4 +22,5 @@ export interface Factory extends Definition {
   lifecycle: Lifecycle,
   resolved?: boolean,
   value?: any,
+  with?: Record<string, any>,
 }


### PR DESCRIPTION
previously you could call resolveWith on the same dependency with different arguments
you would always just get the first resolved value back
now we compare the resolved arguments with the latest arguments
if they don't match, we re-resolve the factory
keep in mind we only do a strict equality match on these parameters

fixes #93